### PR TITLE
Corrige multiply : retourner a * b (multiplication) au lieu de a ** b…

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -36,7 +36,7 @@ def multiply(a, b):
     :param b: Deuxième facteur.
     :return: Le produit de ``a`` et ``b``.
     """
-    return a ** b
+    return a * b
 
 
 def divide(a, b):


### PR DESCRIPTION
… (puissance)


Le test test_multiply vérifie que multiply(3, 4) vaut 12. L'implémentation utilisait l'opérateur puissance (**). Correction pour utiliser la multiplication (*) comme documenté dans la docstring.